### PR TITLE
feature(docker): wait for db to start up

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,6 +27,15 @@ if [ "$FOSSOLOGY_DB_PASSWORD" ]; then
 	db_password="$FOSSOLOGY_DB_PASSWORD"
 fi
 
+testForPostgres(){
+    PGPASSWORD=$db_password psql -h "$db_host" "$db_name" "$db_user" -c '\l' >/dev/null
+    return $?
+}
+until testForPostgres; do
+    >&2 echo "Postgres is unavailable - sleeping"
+    sleep 1
+done
+
 # Write configuration
 cat <<EOM > /usr/local/etc/fossology/Db.conf
 dbname=$db_name;


### PR DESCRIPTION
When tested with the Vagrant setup
```
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure(2) do |config|
  config.vm.box = "box-cutter/ubuntu1404-docker"
  config.vm.provider "virtualbox" do |vb|
  #   vb.gui = true
    vb.memory = 6000
    vb.cpus = 3
  end
  config.vm.network "forwarded_port", guest: 8081, host: 8081
  config.vm.provision "shell", inline: <<-SHELL
    apt-get update
    apt-get install -y git
  SHELL
  config.vm.provision "shell", privileged: false, inline: <<-SHELL
    cd /vagrant/
    rm docker-compose_build.log docker-compose_up.{log,error}
    [ -e docker-compose ] || curl -L https://github.com/docker/compose/releases/download/1.7.0/docker-compose-`uname -s`-`uname -m` > docker-compose 2> /dev/null
    chmod +x docker-compose
    [ -e fossology ] || git clone -b feat/docker --single-branch https://github.com/siemens/fossology
    cd fossology/install
    /vagrant/docker-compose build | tee /vagrant/docker-compose_build.log
  SHELL
  config.vm.provision "shell", run: "always", privileged: false, inline: <<-SHELL
    cd /vagrant/fossology/install
    echo '##################################################################'
    uname -a
    docker --version
    /vagrant/docker-compose --version
    git log -n 1
    echo '##################################################################'
    echo 'run...'
    /vagrant/docker-compose up 2>/vagrant/docker-compose_up.error 1>/vagrant/docker-compose_up.log &
  SHELL
end
```

It was observed, that the **web** container gets ready before the **db** (see https://github.com/fossology/fossology/pull/668#issuecomment-209827041). This adds a loop which waits for the DB to be ready.