### PR TITLE
feat(spdxCompatibleReport): try to improve based on "contrib/spdx-license-status"

### DIFF
--- a/src/lib/php/Data/License.php
+++ b/src/lib/php/Data/License.php
@@ -38,7 +38,7 @@ class License extends LicenseRef
    */
   private $spdxCompatible;
 
-  function __construct($id, $shortName, $fullName, $risk, $text, $url, $spdxCompatible)
+  function __construct($id, $shortName, $fullName, $risk, $text, $url, $spdxCompatible = false)
   {
     parent::__construct($id, $shortName, $fullName);
     $this->text = $text;

--- a/src/spdx2/agent/template/spdx2-document.xml.twig
+++ b/src/spdx2/agent/template/spdx2-document.xml.twig
@@ -23,17 +23,21 @@
   <rdfs:comment> 
     This document was created using license informations and a generator from Fossology.
   </rdfs:comment>
-  {% for licenseId,extractedText in licenseTexts %}
+{% for licenseId,extractedText in licenseTexts %}
   <spdx:hasExtractedLicensingInfo>
-    <spdx:ExtractedLicensingInfo rdf:about="{{ uri }}#LicenseRef-{{ licenseId|replace(' ','-')|url_encode }}">
-      <spdx:licenseId>LicenseRef-{{ licenseId|replace(' ','-')|e }}</spdx:licenseId>
+{% if licenseId starts with 'LicenseRef-' %}
+    <spdx:ExtractedLicensingInfo rdf:about="{{ uri }}#{{ licenseId|replace(' ','-')|url_encode }}">
+{% else %}
+    <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/licenses/{{ licenseId|replace(' ','-')|url_encode }}">
+{% endif %}
+      <spdx:licenseId>{{ licenseId|replace(' ','-')|e }}</spdx:licenseId>
       <spdx:extractedText><![CDATA[
 {{ extractedText|replace({'\f':''})
                 |replace({']]>':']]]]><![CDATA[>'}) }}
       ]]></spdx:extractedText>
     </spdx:ExtractedLicensingInfo>
   </spdx:hasExtractedLicensingInfo>
-  {% endfor %}
+{% endfor %}
   {{ packageNodes|replace({'\n':'\n  '}) }}
 </spdx:SpdxDocument>
 </rdf:RDF>

--- a/src/spdx2/agent/template/spdx2-file.xml.twig
+++ b/src/spdx2/agent/template/spdx2-file.xml.twig
@@ -26,7 +26,11 @@
     <spdx:licenseConcluded>
       <spdx:DisjunctiveLicenseSet>
 {% for res in concludedLicenses %}
-        <spdx:member rdf:resource="{{ uri }}#LicenseRef-{{ res|replace(' ','-')|url_encode }}" />
+{% if res starts with 'LicenseRef-' %}
+        <spdx:member rdf:resource="{{ uri }}#{{ res|replace(' ','-')|url_encode }}" />
+{% else %}
+        <spdx:member rdf:resource="http://spdx.org/licenses/{{ res|replace(' ','-')|url_encode }}" />
+{% endif %}
 {% endfor %}
       </spdx:DisjunctiveLicenseSet>
     </spdx:licenseConcluded>
@@ -37,7 +41,11 @@
 {% if scannerLicenses|default is empty %}
     <spdx:licenseInfoInFile rdf:resource="http://spdx.org/rdf/terms#noassertion" />
 {% else %}{% for res in scannerLicenses %}
-    <spdx:licenseInfoInFile rdf:resource="{{ uri }}#LicenseRef-{{ res|replace(' ','-')|url_encode }}" />
+{% if res starts with 'LicenseRef-' %}
+    <spdx:licenseInfoInFile rdf:resource="{{ uri }}#{{ res|replace(' ','-')|url_encode }}" />
+{% else %}
+    <spdx:licenseInfoInFile rdf:resource="http://spdx.org/licenses/{{ res|replace(' ','-')|url_encode }}" />
+{% endif %}
 {% endfor %}{% endif %}
 {% if copyrights|default is empty %}
     <spdx:copyrightText rdf:resource="http://spdx.org/rdf/terms#noassertion" />

--- a/src/spdx2/agent/template/spdx2-package.xml.twig
+++ b/src/spdx2/agent/template/spdx2-package.xml.twig
@@ -32,7 +32,11 @@
         <spdx:licenseConcluded>
           <spdx:DisjunctiveLicenseSet>
   {% for res in mainLicenses %}
-            <spdx:member rdf:resource="{{ uri }}#LicenseRef-{{ res|replace(' ','-')|url_encode }}" />
+  {% if res starts with 'LicenseRef-' %}
+            <spdx:member rdf:resource="{{ uri }}#{{ res|replace(' ','-')|url_encode }}" />
+  {% else %}
+            <spdx:member rdf:resource="http://spdx.org/licenses/{{ res|replace(' ','-')|url_encode }}" />
+  {% endif %}
   {% endfor %}
           </spdx:DisjunctiveLicenseSet>
         </spdx:licenseConcluded>

--- a/src/spdx2/agent/template/spdx2tv-document.twig
+++ b/src/spdx2/agent/template/spdx2tv-document.twig
@@ -43,7 +43,7 @@ Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-upload{{ packageId }}
 ##-------------------------
 
 {% for licenseId,extractedText in licenseTexts %}
-LicenseID: LicenseRef-{{ licenseId|replace(' ','-') }}
+LicenseID: {{ licenseId|replace(' ','-') }}
 LicenseName: {{ licenseId|replace(' ','-') }}
 ExtractedText: <text> {{ extractedText|replace({'<text>':'&lt;text&gt;','</text>':'&lt;/text&gt;'})
                                       |replace({'\f':''}) }} </text>

--- a/src/spdx2/agent/template/spdx2tv-file.twig
+++ b/src/spdx2/agent/template/spdx2tv-file.twig
@@ -25,7 +25,7 @@ LicenseConcluded: NOASSERTION
 LicenseInfoInFile: NOASSERTION
 {% else %}
 {% for lic in  scannerLicenses %}
-LicenseInfoInFile: LicenseRef-{{ lic|replace({' ':'-'})}}
+LicenseInfoInFile: {{ lic|replace({' ':'-'})}}
 {% endfor %}
 {% endif %}
 {# FileSize: 48 Kb (49173 bytes) #}

--- a/src/spdx2/agent_tests/Unit/spdx2utilTest.php
+++ b/src/spdx2/agent_tests/Unit/spdx2utilTest.php
@@ -56,20 +56,25 @@ class spdx2Test extends \PHPUnit_Framework_TestCase
 
   public function provideLicenseSet()
   {
+    $constTrue = function ($licId) { return true; };
+    $constFalse = function ($licId) { return false; };
+
     return array(
-        'null' => array(null, '',  ''),
-        'empty array' => array(array(), '', ''),
-        'empty array but prefix' => array(array(), 'pre', ''),
-        'single license'=>array(array("LIC1"), '', 'LIC1'),
-        'multiple licenses' => array(array("LIC1","LIC2","LIC3"), '', 'LIC1 AND LIC2 AND LIC3'),
-        'dual license 1st pos' => array(array("Dual-license", "LIC2", "LIC3"), '', 'LIC2 OR LIC3'),
-        'dual license 2nd pos' => array(array("LIC1", "Dual-license", "LIC3"), '', 'LIC1 OR LIC3'),
-        'dual license 3rd pos' => array(array("LIC1", "LIC2", "Dual-license"), '',  'LIC1 OR LIC2'),
-        'dual license with prefix' => array(array("LIC1","LIC2", "Dual-license"), 'pre-', 'pre-LIC1 OR pre-LIC2'),
-        'multiple dualLicense' => array(array("LIC1","LIC2 OR LIC3"),  '', '(LIC2 OR LIC3) AND LIC1'),
-        'multiple dualLicense with prefix' => array(array("LIC1","LIC2 OR LIC3"), 'pre-', '(LIC2 OR LIC3) AND pre-LIC1'),
-        'dual multi license' => array(array("LIC1","LIC2 OR LIC3", "Dual-license"), '', '(LIC2 OR LIC3) OR LIC1'),
-        'dual multi license with prefix' => array(array("LIC1","LIC2 OR LIC3", "Dual-license"), 'pre-', '(LIC2 OR LIC3) OR pre-LIC1'),
+        'null' => array(null, $constTrue,  ''),
+        'empty array' => array(array(), $constTrue, ''),
+        'empty array but prefix' => array(array(), $constFalse, ''),
+        'single license' => array(array("LIC1"), $constTrue, 'LIC1'),
+        'multiple licenses' => array(array("LIC1","LIC2","LIC3"), $constTrue, 'LIC1 AND LIC2 AND LIC3'),
+        'dual license 1st pos' => array(array("Dual-license", "LIC2", "LIC3"), $constTrue, 'LIC2 OR LIC3'),
+        'dual license 2nd pos' => array(array("LIC1", "Dual-license", "LIC3"), $constTrue, 'LIC1 OR LIC3'),
+        'dual license 3rd pos' => array(array("LIC1", "LIC2", "Dual-license"), $constTrue,  'LIC1 OR LIC2'),
+        'dual license with prefix' => array(array("LIC1","LIC2", "Dual-license"), function ($licId) { return $licId === 'LIC2';}, SpdxTwoUtils::$prefix.'LIC1 OR LIC2'),
+        'dual license with prefix' => array(array("LIC1","LIC2", "Dual-license"), function ($licId) { return $licId === 'LIC1';}, 'LIC1 OR '.SpdxTwoUtils::$prefix.'LIC2'),
+        'dual license with prefix ($constFalse)' => array(array("LIC1","LIC2", "Dual-license"), $constFalse, SpdxTwoUtils::$prefix.'LIC1 OR '.SpdxTwoUtils::$prefix.'LIC2'),
+        'multiple dualLicense' => array(array("LIC1","LIC2 OR LIC3"),  $constTrue, '(LIC2 OR LIC3) AND LIC1'),
+        'multiple dualLicense with prefix' => array(array("LIC1","LIC2 OR LIC3"), $constFalse, '(LIC2 OR LIC3) AND '.SpdxTwoUtils::$prefix.'LIC1'),
+        'dual multi license' => array(array("LIC1","LIC2 OR LIC3", "Dual-license"), $constTrue, '(LIC2 OR LIC3) OR LIC1'),
+        'dual multi license with prefix' => array(array("LIC1","LIC2 OR LIC3", "Dual-license"), $constFalse, '(LIC2 OR LIC3) OR '.SpdxTwoUtils::$prefix.'LIC1'),
     );
   }
 


### PR DESCRIPTION
Hi @shaheemazmalmmd.

I have tried to understand and extend your PR.

My idea was to move all logic on the decisions whether to use a prefix to the `SpdxTwoUtils::implodeLicenses` function. But I am still not sure whether this is the right way.

But, both our aproaches, still do not attack the list of license texts at the end of the generated file.

There are still many improvements needed and the result of this PR is by far not complete. But I hope that this contains some usefull parts for you. I will tomorrow continue working on this.