### PR TITLE
fix(spdx2): implement comments suggested in #803 

### DIFF
--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -440,7 +440,7 @@ class SpdxTwoAgent extends Agent
         if($shortName != 'No_license_found'){
           $filesWithLicenses[$row['uploadtree_pk']]['scanner'][] = $shortName;
         }else{
-          $filesWithLicenses[$row['uploadtree_pk']]['scanner'][] = "";
+          $filesWithLicenses[$row['uploadtree_pk']]['scanner'][] = "NONE";
         }
         $this->includedLicenseIds[$reportedLicenseId] = true;
       }

--- a/src/spdx2/agent/spdx2.php
+++ b/src/spdx2/agent/spdx2.php
@@ -436,8 +436,12 @@ class SpdxTwoAgent extends Agent
     {
       $reportedLicenseId = $this->licenseMap->getProjectedId($row['rf_fk']);
       $shortName = $this->licenseMap->getProjectedShortname($reportedLicenseId);
-      if ($shortName != 'No_license_found' && $shortName != 'Void') {
-        $filesWithLicenses[$row['uploadtree_pk']]['scanner'][] = $shortName;
+      if ($shortName != 'Void') {
+        if($shortName != 'No_license_found'){
+          $filesWithLicenses[$row['uploadtree_pk']]['scanner'][] = $shortName;
+        }else{
+          $filesWithLicenses[$row['uploadtree_pk']]['scanner'][] = "";
+        }
         $this->includedLicenseIds[$reportedLicenseId] = true;
       }
     }

--- a/src/spdx2/agent/spdx2utils.php
+++ b/src/spdx2/agent/spdx2utils.php
@@ -63,7 +63,11 @@ class SpdxTwoUtils
       }
       else
       {
-        return self::$prefix . $license;
+        if(!empty($license)){
+          return self::$prefix . $license;
+        }else{
+          return "NOASSERTION";
+        }
       }
     }
   }

--- a/src/spdx2/agent/spdx2utils.php
+++ b/src/spdx2/agent/spdx2utils.php
@@ -49,6 +49,9 @@ class SpdxTwoUtils
    */
   static public function addPrefixOnDemand($license, $spdxValidityChecker = null)
   {
+    if($license === "NOASSERTION" || $license === "NONE"){
+        return $license;
+    }
     if(strpos($license, " OR ") !== false)
     {
       return "(" . $license . ")";


### PR DESCRIPTION
@shaheemazmalmmd this PR adds the changes suggested in the discussion of #803

Whether the line 443 of `spdx2.php` should return `"NONE"` or `"NOASSERTION"` is not completely discussed yet.